### PR TITLE
removed contradicting test

### DIFF
--- a/spec/sinatra_ar_crud_lab_spec.rb
+++ b/spec/sinatra_ar_crud_lab_spec.rb
@@ -128,12 +128,6 @@ describe "Blog Post App" do
       expect(Post.last.name).to eq("Hello World")
     end
 
-    it "displays a view telling us which post was deleted" do
-      visit "/posts/#{@post2.id}"
-      click_button "delete"
-      expect(page.body).to include("#{@post2.name} was deleted")
-    end
-
     it "submits the form via a delete request" do
       visit "/posts/#{@post2.id}"
       expect(find("#hidden", :visible => false).value).to eq("delete")


### PR DESCRIPTION
@PeterBell @AnnJohn @mendel I just removed an old test that expected users to show a flash message for a post being deleted. As we do not cover this it makes no sense for this test to exist, and students are just creating deleted page views to pass this test (not ideal). closes #27 #24 #23
