### PR TITLE
dynamic env in suggested command to fix errors.

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -7,10 +7,7 @@ def fi_check_migration
   begin
     ActiveRecord::Migration.check_pending!
   rescue ActiveRecord::PendingMigrationError
-    raise ActiveRecord::PendingMigrationError.new <<-EX_MSG
-Migrations are pending. To resolve this issue, run:
-      rake db:migrate SINATRA_ENV=test
-EX_MSG
+    raise ActiveRecord::PendingMigrationError.new "Migrations are pending.\nTo resolve this issue, run: \nrake db:migrate SINATRA_ENV=#{ENV['SINATRA_ENV']}"
   end
 end
 


### PR DESCRIPTION
printing =test was hardcoded.
I switched it to `#{ENV['SINATRA_ENV']}` because sometimes you run `shotgun` in a development environment and you'd need to run the development migrations while the test ones wouldn't help. And the error message would still ask for test migrations!

I did NOT TEST the `\n` characters in the string for the error message.
Maybe 2 more should be added.